### PR TITLE
Fix for issue #468, #461, #460 and minor cleanup (#469)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,5 +1,5 @@
 Thank you for making a pull request ! Just a gentle reminder :)
 
 1. If the PR is offering a feature please make the request to our "Feature Branch" 0.11.0
-2. Bug fix request to "Bug Fix Branch" 0.10.8
+2. Bug fix request to "Bug Fix Branch" 0.10.9
 3. Correct README.md can directly to master

--- a/android.js
+++ b/android.js
@@ -13,7 +13,7 @@ const RNFetchBlob:RNFetchBlobNative = NativeModules.RNFetchBlob
 
 /**
  * Send an intent to open the file.
- * @param  {string]} path Path of the file to be open.
+ * @param  {string} path Path of the file to be open.
  * @param  {string} mime MIME type string
  * @return {Promise}
  */

--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlobFS.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlobFS.java
@@ -78,7 +78,7 @@ public class RNFetchBlobFS {
                 data = normalizePath(data);
                 File src = new File(data);
                 if(!src.exists()) {
-                    promise.reject("RNfetchBlob writeFileError", "source file : " + data + "not exists");
+                    promise.reject("RNfetchBlob writeFile error", "source file : " + data + " does not exist");
                     fout.close();
                     return ;
                 }
@@ -100,7 +100,7 @@ public class RNFetchBlobFS {
             fout.close();
             promise.resolve(written);
         } catch (Exception e) {
-            promise.reject("RNFetchBlob writeFileError", e.getLocalizedMessage());
+            promise.reject("RNFetchBlob writeFile error", e.getLocalizedMessage());
         }
     }
 
@@ -127,7 +127,7 @@ public class RNFetchBlobFS {
             os.close();
             promise.resolve(data.size());
         } catch (Exception e) {
-            promise.reject("RNFetchBlob writeFileError", e.getLocalizedMessage());
+            promise.reject("RNFetchBlob writeFile error", e.getLocalizedMessage());
         }
     }
 
@@ -309,7 +309,8 @@ public class RNFetchBlobFS {
             buffer = null;
 
         } catch (Exception err) {
-            emitStreamEvent(streamId, "warn", "Failed to convert data to "+encoding+" encoded string, this might due to the source data is not able to convert using this encoding.");
+            emitStreamEvent(streamId, "warn", "Failed to convert data to " + encoding +
+                    " encoded string, this might due to the source data is not able to convert using this encoding.");
             err.printStackTrace();
         }
     }
@@ -324,7 +325,7 @@ public class RNFetchBlobFS {
     public void writeStream(String path, String encoding, boolean append, Callback callback) {
         File dest = new File(path);
         if(!dest.exists() || dest.isDirectory()) {
-            callback.invoke("write stream error: target path `" + path + "` may not exists or it's a folder");
+            callback.invoke("target path `" + path + "` may not exist or it is a folder");
             return;
         }
         try {
@@ -336,7 +337,7 @@ public class RNFetchBlobFS {
             this.writeStreamInstance = fs;
             callback.invoke(null, streamId);
         } catch(Exception err) {
-            callback.invoke("write stream error: failed to create write stream at path `"+path+"` "+ err.getLocalizedMessage());
+            callback.invoke("failed to create write stream at path `" + path + "` " + err.getLocalizedMessage());
         }
 
     }
@@ -433,12 +434,13 @@ public class RNFetchBlobFS {
     static void mkdir(String path, Callback callback) {
         File dest = new File(path);
         if(dest.exists()) {
-            callback.invoke("mkdir error: failed to create folder at `" + path + "` folder already exists");
+            callback.invoke("mkdir failed, folder already exists at " + path);
             return;
         }
         dest.mkdirs();
         callback.invoke();
     }
+
     /**
      * Copy file to destination path
      * @param path Source path
@@ -454,7 +456,7 @@ public class RNFetchBlobFS {
         try {
 
             if(!isPathExists(path)) {
-                callback.invoke("cp error: source file at path`" + path + "` not exists");
+                callback.invoke("source file at path`" + path + "` does not exist");
                 return;
             }
             if(!new File(dest).exists())
@@ -495,7 +497,7 @@ public class RNFetchBlobFS {
     static void mv(String path, String dest, Callback callback) {
         File src = new File(path);
         if(!src.exists()) {
-            callback.invoke("mv error: source file at path `" + path + "` does not exists");
+            callback.invoke("source file at path `" + path + "` does not exist");
             return;
         }
         src.renameTo(new File(dest));
@@ -535,7 +537,7 @@ public class RNFetchBlobFS {
         path = normalizePath(path);
         File src = new File(path);
         if (!src.exists() || !src.isDirectory()) {
-            callback.invoke("ls error: failed to list path `" + path + "` for it is not exist or it is not a folder");
+            callback.invoke("failed to list path `" + path + "` for it is not exist or it is not a folder");
             return;
         }
         String[] files = new File(path).list();
@@ -559,7 +561,7 @@ public class RNFetchBlobFS {
             src = normalizePath(src);
             File source = new File(src);
             if(!source.exists()) {
-                promise.reject("RNFetchBlob.slice error", "source file : " + src + " not exists");
+                promise.reject("RNFetchBlob slice error", "source file : " + src + " does not exist");
                 return;
             }
             long size = source.length();
@@ -585,7 +587,7 @@ public class RNFetchBlobFS {
             promise.resolve(dest);
         } catch (Exception e) {
             e.printStackTrace();
-            promise.reject(e.getLocalizedMessage());
+            promise.reject("RNFetchBlob slice error", e.getLocalizedMessage());
         }
     }
 
@@ -597,18 +599,18 @@ public class RNFetchBlobFS {
             protected Integer doInBackground(String ...args) {
                 WritableArray res = Arguments.createArray();
                 if(args[0] == null) {
-                    callback.invoke("lstat error: the path specified for lstat is either `null` or `undefined`.");
+                    callback.invoke("the path specified for lstat is either `null` or `undefined`.");
                     return 0;
                 }
                 File src = new File(args[0]);
                 if(!src.exists()) {
-                    callback.invoke("lstat error: failed to list path `" + args[0] + "` for it is not exist or it is not a folder");
+                    callback.invoke("failed to lstat path `" + args[0] + "` because it does not exist or it is not a folder");
                     return 0;
                 }
                 if(src.isDirectory()) {
                     String [] files = src.list();
                     for(String p : files) {
-                        res.pushMap(statFile ( src.getPath() + "/" + p));
+                        res.pushMap(statFile(src.getPath() + "/" + p));
                     }
                 }
                 else {
@@ -630,7 +632,7 @@ public class RNFetchBlobFS {
             path = normalizePath(path);
             WritableMap result = statFile(path);
             if(result == null)
-                callback.invoke("stat error: failed to list path `" + path + "` for it is not exist or it is not a folder", null);
+                callback.invoke("failed to stat path `" + path + "` because it does not exist or it is not a folder", null);
             else
                 callback.invoke(null, result);
         } catch(Exception err) {
@@ -709,23 +711,24 @@ public class RNFetchBlobFS {
                 String orgPath = data.replace(RNFetchBlobConst.FILE_PREFIX, "");
                 File src = new File(orgPath);
                 if(!src.exists()) {
-                    callback.invoke("RNfetchBlob writeFileError", "source file : " + data + "not exists");
+                    callback.invoke("source file : " + data + " does not exist");
                     return ;
                 }
                 FileInputStream fin = new FileInputStream(src);
                 OutputStream ostream = new FileOutputStream(dest);
-                byte [] buffer = new byte [10240];
+                byte[] buffer = new byte[10240];
                 int read = fin.read(buffer);
-                while(read > 0) {
+                while (read > 0) {
                     ostream.write(buffer, 0, read);
                     read = fin.read(buffer);
                 }
                 fin.close();
                 ostream.close();
-            }
-            else {
+            } else {
                 if (!created) {
-                    callback.invoke("create file error: failed to create file at path `" + path + "` for its parent path may not exists, or the file already exists. If you intended to overwrite the existing file use fs.writeFile instead.");
+                    callback.invoke("failed to create new file at path `" + path + "` because its parent path " +
+                            "may not exist, or the file already exists. If you intended to overwrite the " +
+                            "existing file use fs.writeFile instead.");
                     return;
                 }
                 OutputStream ostream = new FileOutputStream(dest);
@@ -747,12 +750,12 @@ public class RNFetchBlobFS {
         try {
             File dest = new File(path);
             if(dest.exists()) {
-                callback.invoke("create file error: failed to create file at path `" + path + "`, file already exists.");
+                callback.invoke("failed to create new file at path `" + path + "`, file already exists.");
                 return;
             }
             boolean created = dest.createNewFile();
             if(!created) {
-                callback.invoke("create file error: failed to create file at path `" + path + "` for its parent path may not exists");
+                callback.invoke("failed to create new file at path `" + path + "` because its parent path may not exist");
                 return;
             }
             OutputStream ostream = new FileOutputStream(dest);

--- a/class/RNFetchBlobSession.js
+++ b/class/RNFetchBlobSession.js
@@ -9,16 +9,11 @@ import {
 } from 'react-native'
 
 const RNFetchBlob = NativeModules.RNFetchBlob
-const emitter = DeviceEventEmitter
 
 let sessions = {}
 
 export default class RNFetchBlobSession {
 
-  add : (path:string) => RNFetchBlobSession;
-  remove : (path:string) => RNFetchBlobSession;
-  dispose : () => Promise;
-  list : () => Array<string>;
   name : string;
 
   static getSession(name:string):any {
@@ -50,7 +45,7 @@ export default class RNFetchBlobSession {
 
   remove(path:string):RNFetchBlobSession {
     let list = sessions[this.name]
-    for(let i in list) {
+    for(let i of list) {
       if(list[i] === path) {
         sessions[this.name].splice(i, 1)
         break;
@@ -67,7 +62,7 @@ export default class RNFetchBlobSession {
     return new Promise((resolve, reject) => {
       RNFetchBlob.removeSession(sessions[this.name], (err) => {
         if(err)
-          reject(err)
+          reject(new Error(err))
         else {
           delete sessions[this.name]
           resolve()

--- a/class/RNFetchBlobWriteStream.js
+++ b/class/RNFetchBlobWriteStream.js
@@ -9,15 +9,14 @@ import {
 } from 'react-native'
 
 const RNFetchBlob = NativeModules.RNFetchBlob
-const emitter = DeviceEventEmitter
 
 export default class RNFetchBlobWriteStream {
 
   id : string;
   encoding : string;
-  append : bool;
+  append : boolean;
 
-  constructor(streamId:string, encoding:string, append:string) {
+  constructor(streamId:string, encoding:string, append:boolean) {
     this.id = streamId
     this.encoding = encoding
     this.append = append
@@ -28,17 +27,17 @@ export default class RNFetchBlobWriteStream {
       try {
         let method = this.encoding === 'ascii' ? 'writeArrayChunk' : 'writeChunk'
         if(this.encoding.toLocaleLowerCase() === 'ascii' && !Array.isArray(data)) {
-            reject('ascii input data must be an Array')
+            reject(new Error('ascii input data must be an Array'))
             return
         }
         RNFetchBlob[method](this.id, data, (error) => {
           if(error)
-            reject(error)
+            reject(new Error(error))
           else
             resolve()
         })
       } catch(err) {
-        reject(err)
+        reject(new Error(err))
       }
     })
   }
@@ -50,7 +49,7 @@ export default class RNFetchBlobWriteStream {
           resolve()
         })
       } catch (err) {
-        reject(err)
+        reject(new Error(err))
       }
     })
   }

--- a/fs.js
+++ b/fs.js
@@ -19,7 +19,7 @@ import type {
 } from './types'
 
 const RNFetchBlob:RNFetchBlobNative = NativeModules.RNFetchBlob
-const emitter = DeviceEventEmitter
+
 const dirs = {
     DocumentDir :  RNFetchBlob.DocumentDir,
     CacheDir : RNFetchBlob.CacheDir,
@@ -83,13 +83,13 @@ function createFile(path:string, data:string, encoding: 'base64' | 'ascii' | 'ut
  * Create write stream to a file.
  * @param  {string} path Target path of file stream.
  * @param  {string} encoding Encoding of input data.
- * @param  {bool} append  A flag represent if data append to existing ones.
- * @return {Promise<WriteStream>} A promise resolves a `WriteStream` object.
+ * @param  {boolean} [append]  A flag represent if data append to existing ones.
+ * @return {Promise<RNFetchBlobWriteStream>} A promise resolves a `WriteStream` object.
  */
 function writeStream(
   path : string,
   encoding : 'utf8' | 'ascii' | 'base64',
-  append? : ?bool,
+  append? : ?boolean,
 ):Promise<RNFetchBlobWriteStream> {
   if(!path)
     throw Error('RNFetchBlob could not open file stream with empty `path`')
@@ -110,6 +110,7 @@ function writeStream(
  * @param  {string} path   The file path.
  * @param  {string} encoding Data encoding, should be one of `base64`, `utf8`, `ascii`
  * @param  {boolean} bufferSize Size of stream buffer.
+ * @param  {number} [tick=10] Interval in milliseconds between reading chunks of data
  * @return {RNFetchBlobStream} RNFetchBlobStream stream instance.
  */
 function readStream(
@@ -154,7 +155,7 @@ function pathForAppGroup(groupName:string):Promise {
  * @param  {'base64' | 'utf8' | 'ascii'} encoding Encoding of read stream.
  * @return {Promise<Array<number> | string>}
  */
-function readFile(path:string, encoding:string, bufferSize:?number):Promise<any> {
+function readFile(path:string, encoding:string):Promise<any> {
   if(typeof path !== 'string')
     return Promise.reject(new Error('Invalid argument "path" '))
   return RNFetchBlob.readFile(path, encoding)
@@ -170,7 +171,7 @@ function readFile(path:string, encoding:string, bufferSize:?number):Promise<any>
 function writeFile(path:string, data:string | Array<number>, encoding:?string):Promise {
   encoding = encoding || 'utf8'
   if(typeof path !== 'string')
-    return Promise.reject('Invalid argument "path" ')
+    return Promise.reject(new Error('Invalid argument "path" '))
   if(encoding.toLocaleLowerCase() === 'ascii') {
     if(!Array.isArray(data))
       return Promise.reject(new Error(`Expected "data" is an Array when encoding is "ascii", however got ${typeof data}`))
@@ -187,7 +188,7 @@ function writeFile(path:string, data:string | Array<number>, encoding:?string):P
 function appendFile(path:string, data:string | Array<number>, encoding:?string):Promise {
   encoding = encoding || 'utf8'
   if(typeof path !== 'string')
-    return Promise.reject('Invalid argument "path" ')
+    return Promise.reject(new Error('Invalid argument "path" '))
   if(encoding.toLocaleLowerCase() === 'ascii') {
     if(!Array.isArray(data))
       return Promise.reject(new Error(`Expected "data" is an Array when encoding is "ascii", however got ${typeof data}`))
@@ -224,7 +225,7 @@ function stat(path:string):Promise<RNFetchBlobFile> {
 
 /**
  * Android only method, request media scanner to scan the file.
- * @param  {Array<Object<string, string>>} Array contains Key value pairs with key `path` and `mime`.
+ * @param  {Array<Object<string, string>>} pairs Array contains Key value pairs with key `path` and `mime`.
  * @return {Promise}
  */
 function scanFile(pairs:any):Promise {
@@ -302,10 +303,9 @@ function unlink(path:string):Promise {
 /**
  * Check if file exists and if it is a folder.
  * @param  {string} path Path to check
- * @return {Promise<bool, bool>}
+ * @return {Promise<boolean, boolean>}
  */
-function exists(path:string):Promise<bool, bool> {
-
+function exists(path:string):Promise<boolean, boolean> {
   return new Promise((resolve, reject) => {
     try {
       RNFetchBlob.exists(path, (exist) => {
@@ -358,7 +358,7 @@ function df():Promise<{ free : number, total : number }> {
   return new Promise((resolve, reject) => {
     RNFetchBlob.df((err, stat) => {
       if(err)
-        reject(err)
+        reject(new Error(err))
       else
         resolve(stat)
     })

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ import type {
   RNFetchBlobResponseInfo
 } from './types'
 import URIUtil from './utils/uri'
-import StatefulPromise from './class/StatefulPromise.js'
+//import StatefulPromise from './class/StatefulPromise.js'
 import fs from './fs'
 import getUUID from './utils/uuid'
 import base64 from 'base-64'
@@ -118,7 +118,7 @@ function config (options:RNFetchBlobConfig) {
  * @param  {string} method     Should be one of `get`, `post`, `put`
  * @param  {string} url        A file URI string
  * @param  {string} headers    Arguments of file system API
- * @param  {any} body       Data to put or post to file systen.
+ * @param  {any}    body       Data to put or post to file systen.
  * @return {Promise}
  */
 function fetchFile(options = {}, method, url, headers = {}, body):Promise {
@@ -520,13 +520,12 @@ class FetchBlobResponse {
     }
     /**
      * Start read stream from cached file
-     * @param  {String} encoding Encode type, should be one of `base64`, `ascrii`, `utf8`.
-     * @param  {Function} fn On data event handler
+     * @param  {String} encoding Encode type, should be one of `base64`, `ascii`, `utf8`.
      * @return {void}
      */
-    this.readStream = (encode: 'base64' | 'utf8' | 'ascii'):RNFetchBlobStream | null => {
+    this.readStream = (encoding: 'base64' | 'utf8' | 'ascii'):RNFetchBlobStream | null => {
       if(this.type === 'path') {
-        return readStream(this.data, encode)
+        return readStream(this.data, encoding)
       }
       else {
         console.warn('RNFetchblob', 'this response data does not contains any available stream')
@@ -539,10 +538,10 @@ class FetchBlobResponse {
      * @param  {String} encoding Encode type, should be one of `base64`, `ascrii`, `utf8`.
      * @return {String}
      */
-    this.readFile = (encode: 'base64' | 'utf8' | 'ascii') => {
+    this.readFile = (encoding: 'base64' | 'utf8' | 'ascii') => {
       if(this.type === 'path') {
-        encode = encode || 'utf8'
-        return readFile(this.data, encode)
+          encoding = encoding || 'utf8'
+        return readFile(this.data, encoding)
       }
       else {
         console.warn('RNFetchblob', 'this response does not contains a readable file')

--- a/ios.js
+++ b/ios.js
@@ -13,7 +13,7 @@ const RNFetchBlob:RNFetchBlobNative = NativeModules.RNFetchBlob
 
 /**
  * Open a file using UIDocumentInteractionController
- * @param  {string]} path Path of the file to be open.
+ * @param  {string} path Path of the file to be open.
  * @param  {string} scheme URI scheme that needs to support, optional
  * @return {Promise}
  */
@@ -26,7 +26,7 @@ function previewDocument(path:string, scheme:string) {
 
 /**
  * Preview a file using UIDocumentInteractionController
- * @param  {string]} path Path of the file to be open.
+ * @param  {string} path Path of the file to be open.
  * @param  {string} scheme URI scheme that needs to support, optional
  * @return {Promise}
  */

--- a/ios/RNFetchBlob/RNFetchBlob.m
+++ b/ios/RNFetchBlob/RNFetchBlob.m
@@ -194,7 +194,7 @@ RCT_EXPORT_METHOD(pathForAppGroup:(NSString *)groupName
     if(path) {
         resolve(path);
     } else {
-        reject(@"RNFetchBlob file not found", @"could not find path for app group", nil);
+        reject(@"RNFetchBlob pathForAppGroup Error", @"could not find path for app group", nil);
     }
 }
 
@@ -223,7 +223,7 @@ RCT_EXPORT_METHOD(writeStream:(NSString *)path withEncoding:(NSString *)encoding
     BOOL isDir = nil;
     BOOL exist = [fm fileExistsAtPath:path isDirectory:&isDir];
     if( exist == NO || isDir == YES) {
-        callback(@[[NSString stringWithFormat:@"target path `%@` may not exists or it's a folder", path]]);
+        callback(@[[NSString stringWithFormat:@"target path `%@` may not exist or it is a folder", path]]);
         return;
     }
     NSString * streamId = [fileStream openWithPath:path encode:encoding appendData:append];
@@ -326,7 +326,7 @@ RCT_EXPORT_METHOD(stat:(NSString *)target callback:(RCTResponseSenderBlock) call
 
             exist = [fm fileExistsAtPath:path isDirectory:&isDir];
             if(exist == NO) {
-                callback(@[[NSString stringWithFormat:@"failed to stat path `%@` for it is not exist or it is not exist", path]]);
+                callback(@[[NSString stringWithFormat:@"failed to stat path `%@` because it does not exist or it is not a folder", path]]);
                 return ;
             }
             result = [RNFetchBlobFS stat:path error:&error];
@@ -362,7 +362,7 @@ RCT_EXPORT_METHOD(lstat:(NSString *)path callback:(RCTResponseSenderBlock) callb
 
     exist = [fm fileExistsAtPath:path isDirectory:&isDir];
     if(exist == NO) {
-        callback(@[[NSString stringWithFormat:@"failed to list path `%@` for it is not exist or it is not exist", path]]);
+        callback(@[[NSString stringWithFormat:@"failed to lstat path `%@` because it does not exist or it is not a folder", path]]);
         return ;
     }
     NSError * error = nil;
@@ -447,7 +447,7 @@ RCT_EXPORT_METHOD(readFile:(NSString *)path
     [RNFetchBlobFS readFile:path encoding:encoding onComplete:^(id content, NSString * err) {
         if(err != nil)
         {
-            reject(@"RNFetchBlob failed to read file", err, nil);
+            reject(@"RNFetchBlob readFile Error", err, nil);
             return;
         }
         if(encoding == @"ascii")
@@ -529,7 +529,7 @@ RCT_EXPORT_METHOD(previewDocument:(NSString*)uri scheme:(NSString *)scheme resol
       });
         resolve(@[[NSNull null]]);
     } else {
-        reject(@"RNFetchBlob could not open document", @"scheme is not supported", nil);
+        reject(@"RNFetchBlob previewDocument Error", @"scheme is not supported", nil);
     }
 }
 
@@ -549,7 +549,7 @@ RCT_EXPORT_METHOD(openDocument:(NSString*)uri scheme:(NSString *)scheme resolver
         });
         resolve(@[[NSNull null]]);
     } else {
-        reject(@"RNFetchBlob could not open document", @"scheme is not supported", nil);
+        reject(@"RNFetchBlob openDocument Error", @"scheme is not supported", nil);
     }
 }
 
@@ -563,7 +563,7 @@ RCT_EXPORT_METHOD(excludeFromBackupKey:(NSString *)url resolver:(RCTPromiseResol
     {
         resolve(@[[NSNull null]]);
     } else {
-        reject(@"RNFetchBlob could not open document", [error description], nil);
+        reject(@"RNFetchBlob excludeFromBackupKey Error", [error description], nil);
     }
 
 }

--- a/ios/RNFetchBlobFS.m
+++ b/ios/RNFetchBlobFS.m
@@ -163,7 +163,7 @@ NSMutableDictionary *fileStreams = nil;
             {
                 if([[NSFileManager defaultManager] fileExistsAtPath:path] == NO)
                 {
-                    NSString * message = [NSString stringWithFormat:@"File not exists at path %@", path];
+                    NSString * message = [NSString stringWithFormat:@"File does not exist at path %@", path];
                     NSDictionary * payload = @{ @"event": FS_EVENT_ERROR, @"detail": message };
                     [event sendDeviceEventWithName:streamId body:payload];
                     free(buffer);
@@ -254,11 +254,11 @@ NSMutableDictionary *fileStreams = nil;
                     [asciiArray addObject:[NSNumber numberWithChar:bytePtr[i]]];
                 }
             }
-            
+
             NSDictionary * payload = @{ @"event": FS_EVENT_DATA,  @"detail" : asciiArray };
             [event sendDeviceEventWithName:streamId body:payload];
         }
-        
+
     }
     @catch (NSException * ex)
     {
@@ -335,7 +335,7 @@ NSMutableDictionary *fileStreams = nil;
     @try {
         NSFileManager * fm = [NSFileManager defaultManager];
         NSError * err = nil;
-        // check if the folder exists, if not exists, create folders recursively
+        // check if the folder exists, if it does not exist create folders recursively
         // after the folders created, write data into the file
         NSString * folder = [path stringByDeletingLastPathComponent];
         encoding = [encoding lowercaseString];
@@ -452,13 +452,13 @@ NSMutableDictionary *fileStreams = nil;
         else
         {
             if(![[NSFileManager defaultManager] fileExistsAtPath:path]) {
-                onComplete(nil, @"file not exists");
+                onComplete(nil, @"file does not exist");
                 return;
             }
             fileContent = [NSData dataWithContentsOfFile:path];
-            
+
         }
-        
+
         if(encoding != nil)
         {
             if([[encoding lowercaseString] isEqualToString:@"utf8"])
@@ -485,7 +485,7 @@ NSMutableDictionary *fileStreams = nil;
         {
             onComplete(fileContent, nil);
         }
-        
+
     }];
 }
 
@@ -495,7 +495,7 @@ NSMutableDictionary *fileStreams = nil;
 + (BOOL) mkdir:(NSString *) path {
     BOOL isDir;
     NSError * err = nil;
-    // if temp folder not exists, create one
+    // if temp folder does not exist create it
     if(![[NSFileManager defaultManager] fileExistsAtPath: path isDirectory:&isDir]) {
         [[NSFileManager defaultManager] createDirectoryAtPath:path withIntermediateDirectories:YES attributes:nil error:&err];
     }
@@ -571,7 +571,7 @@ NSMutableDictionary *fileStreams = nil;
     NSData * decodedData = nil;
     if([[self.encoding lowercaseString] isEqualToString:@"base64"]) {
         decodedData = [[NSData alloc] initWithBase64EncodedString:chunk options: NSDataBase64DecodingIgnoreUnknownCharacters];
-    } 
+    }
     else if([[self.encoding lowercaseString] isEqualToString:@"utf8"]) {
         decodedData = [chunk dataUsingEncoding:NSUTF8StringEncoding];
     }
@@ -632,10 +632,10 @@ NSMutableDictionary *fileStreams = nil;
             NSFileManager * fm = [NSFileManager defaultManager];
             NSOutputStream * os = [[NSOutputStream alloc] initToFileAtPath:dest append:NO];
             [os open];
-            // abort for the source file not exists
+            // abort because the source file does not exist
             if([fm fileExistsAtPath:path] == NO)
             {
-                reject(@"RNFetchBlob slice failed : the file does not exists", path, nil);
+                reject(@"RNFetchBlob slice Error : the file does not exist", path, nil);
                 return;
             }
             long size = [fm attributesOfItemAtPath:path error:nil].fileSize;
@@ -712,7 +712,7 @@ NSMutableDictionary *fileStreams = nil;
         }
         else
         {
-            reject(@"slice error",  [NSString stringWithFormat: @"could not resolve URI %@", path ], nil);
+            reject(@"RNFetchBlob slice Error",  [NSString stringWithFormat: @"could not resolve URI %@", path ], nil);
         }
 
     }];
@@ -765,7 +765,7 @@ NSMutableDictionary *fileStreams = nil;
     if (dictionary) {
         NSNumber *fileSystemSizeInBytes = [dictionary objectForKey: NSFileSystemSize];
         NSNumber *freeFileSystemSizeInBytes = [dictionary objectForKey:NSFileSystemFreeSize];
-        
+
         callback(@[[NSNull null], @{
                   @"free" : freeFileSystemSizeInBytes,
                   @"total" : fileSystemSizeInBytes,

--- a/json-stream.js
+++ b/json-stream.js
@@ -2,14 +2,17 @@ import Oboe from './lib/oboe-browser.min.js'
 import XMLHttpRequest from './polyfill/XMLHttpRequest'
 import URIUtil from './utils/uri'
 
-const OboeExtended = (arg: string | object) => {
+const OboeExtended = (arg: string | Object) => {
 
 
   window.location = ''
 
   if(!window.XMLHttpRequest.isRNFBPolyfill ) {
     window.XMLHttpRequest = XMLHttpRequest
-    console.warn('Use JSONStream will automatically replace window.XMLHttpRequest with RNFetchBlob.polyfill.XMLHttpRequest. You are seeing this warning because you did not replace it maually.')
+    console.warn(
+        'Use JSONStream will automatically replace window.XMLHttpRequest with RNFetchBlob.polyfill.XMLHttpRequest. ' +
+        'You are seeing this warning because you did not replace it manually.'
+    )
   }
 
   if(typeof arg === 'string') {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-fetch-blob",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "description": "A module provides upload, download, and files access API. Supports file stream read/write for process large files.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
* bump to 0.10.8

* Update PULL_REQUEST_TEMPLATE

* Fix #468 "Messy error returns: Sometimes a string, sometimes an Error object"

* Cleanup: remove an unused constant and duplicate method definitions

* Cleanup:
- fix minor errors in JSDoc comments, for example {string]} => {string}
- fix parameter name "encode" => "encoding" (more logical, and it says so in the function's JSDoc too)
- json-stream.js: split a looooong log message string constant into two parts and fix a typo ("maually"), and the type for objects is "Object" (capitalized) in Flow type annotations

* Fix a (Flow) type conflict - fixes issue #461

* NEEDS REVIEW - Attempt to fix some of issue #460 (Error message normalization)

Error messages reported by iOS and Android versions should be as similar as possible. Also, within the same system there should be consistency. This patch is an attempt to bring a LITTLE more of this consistency to the error messages. I also fixed some very few minor language issues, like "does not exist" (is the correct English). I tried keeping the changes to a minimum.

Background: In my project code I want to know when a file already exists (e.g. after calling fs.createFile), and the only way is to check the error message string that I get. It's bad if they differ between versions (createFileASCII and createFile) and then also between Android and iOS version. At least some core part of the string should be the same, so that I have something to match.

Ideally messages should come from a centralized easy (easier) to maintain file (for both iOS and Android), and ideally both systems should have the same errors and messages as far as possible.

Thank you for making a pull request ! Just a gentle reminder :)

1. If the PR is offering a feature please make the request to our "Feature Branch" 0.11.0
2. Bug fix request to "Bug Fix Branch" 0.10.9
3. Correct README.md can directly to master
